### PR TITLE
Fix cars getting stuck in tiny gaps in dirt path and soul sand

### DIFF
--- a/src/main/java/io/github/a5h73y/carz/listeners/VehicleListener.java
+++ b/src/main/java/io/github/a5h73y/carz/listeners/VehicleListener.java
@@ -235,7 +235,7 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
 
         Vector vehicleVelocity = event.getVehicle().getVelocity();
         Vector playerLocationVelocity = player.getLocation().getDirection();
-        Block blockBelow = event.getVehicle().getLocation().subtract(0.0D, 0.8D, 0.0D).getBlock(); // Pea9e
+        Block blockBelow = event.getVehicle().getLocation().subtract(0.0D, 0.8D, 0.0D).getBlock();
         Material materialBelow = blockBelow.getType();
         BlocksConfig blocksConfig = (BlocksConfig) Carz.getConfig(BLOCKS);
 
@@ -258,7 +258,7 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
         playerLocation.setPitch(0f);
 
         Location twoBlocksAhead = playerLocation.add(playerLocation.getDirection().multiply(2));
-        twoBlocksAhead.setY(Math.max(playerLocation.getY() + getBlockHeight(twoBlocksAhead.getBlock()), twoBlocksAhead.getY())); // Pdf95
+        twoBlocksAhead.setY(Math.max(playerLocation.getY() + getBlockHeight(twoBlocksAhead.getBlock()), twoBlocksAhead.getY()));
 
         // determine if the Car should start climbing
         boolean isClimbable = calculateIsClimbable(blockBelow, twoBlocksAhead, blocksConfig);
@@ -298,14 +298,13 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
         return blocksConfig.getClimbBlocks().contains(twoBlocksAhead.getBlock().getType());
     }
 
-    private double getBlockHeight(Block block) { // Pc2f4
+    private double getBlockHeight(Block block) {
         switch (block.getType()) {
             case DIRT_PATH:
             case FARMLAND:
             case HONEY_BLOCK:
-                return 0.0625;
             case SOUL_SAND:
-                return 0.125;
+                return 0.47;
             default:
                 return 1.0;
         }

--- a/src/main/java/io/github/a5h73y/carz/listeners/VehicleListener.java
+++ b/src/main/java/io/github/a5h73y/carz/listeners/VehicleListener.java
@@ -235,7 +235,7 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
 
         Vector vehicleVelocity = event.getVehicle().getVelocity();
         Vector playerLocationVelocity = player.getLocation().getDirection();
-        Block blockBelow = event.getVehicle().getLocation().subtract(0.0D, 1.0D, 0.0D).getBlock();
+        Block blockBelow = event.getVehicle().getLocation().subtract(0.0D, 0.8D, 0.0D).getBlock(); // Pea9e
         Material materialBelow = blockBelow.getType();
         BlocksConfig blocksConfig = (BlocksConfig) Carz.getConfig(BLOCKS);
 
@@ -258,7 +258,7 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
         playerLocation.setPitch(0f);
 
         Location twoBlocksAhead = playerLocation.add(playerLocation.getDirection().multiply(2));
-        twoBlocksAhead.setY(Math.max(playerLocation.getY() + 1, twoBlocksAhead.getY()));
+        twoBlocksAhead.setY(Math.max(playerLocation.getY() + getBlockHeight(twoBlocksAhead.getBlock()), twoBlocksAhead.getY())); // Pdf95
 
         // determine if the Car should start climbing
         boolean isClimbable = calculateIsClimbable(blockBelow, twoBlocksAhead, blocksConfig);
@@ -296,6 +296,19 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
 
         // if there are climb blocks, make sure the material matches the whitelist
         return blocksConfig.getClimbBlocks().contains(twoBlocksAhead.getBlock().getType());
+    }
+
+    private double getBlockHeight(Block block) { // Pc2f4
+        switch (block.getType()) {
+            case DIRT_PATH:
+            case FARMLAND:
+            case HONEY_BLOCK:
+                return 0.0625;
+            case SOUL_SAND:
+                return 0.125;
+            default:
+                return 1.0;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #48

Update `VehicleListener.java` to allow cars to climb out of tiny gaps in dirt path, soul sand, farmland, and honey blocks.

* Adjust the calculation for the blocks below by subtracting 0.8 instead of 1.0 in the `onVehicleUpdate` method.
* Add a new method `getBlockHeight` to calculate the correct height for different block types.
* Modify the `twoBlocksAhead.setY` calculation to use the `getBlockHeight` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/A5H73Y/Carz/issues/48?shareId=7764461e-05ec-4493-9782-3ee01ebf78b2).