### PR TITLE
Fix cars getting stuck in tiny gaps in dirt path and soul sand

### DIFF
--- a/src/main/java/io/github/a5h73y/carz/listeners/VehicleListener.java
+++ b/src/main/java/io/github/a5h73y/carz/listeners/VehicleListener.java
@@ -235,7 +235,7 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
 
         Vector vehicleVelocity = event.getVehicle().getVelocity();
         Vector playerLocationVelocity = player.getLocation().getDirection();
-        Block blockBelow = event.getVehicle().getLocation().subtract(0.0D, 1.0D, 0.0D).getBlock();
+        Block blockBelow = event.getVehicle().getLocation().subtract(0.0D, 0.1D, 0.0D).getBlock();
         Material materialBelow = blockBelow.getType();
         BlocksConfig blocksConfig = (BlocksConfig) Carz.getConfig(BLOCKS);
 
@@ -258,7 +258,7 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
         playerLocation.setPitch(0f);
 
         Location twoBlocksAhead = playerLocation.add(playerLocation.getDirection().multiply(2));
-        twoBlocksAhead.setY(Math.max(playerLocation.getY() + 1, twoBlocksAhead.getY()));
+        twoBlocksAhead.setY(Math.max(playerLocation.getY() + getBlockHeight(twoBlocksAhead.getBlock()), twoBlocksAhead.getY()));
 
         // determine if the Car should start climbing
         boolean isClimbable = calculateIsClimbable(blockBelow, twoBlocksAhead, blocksConfig);
@@ -296,6 +296,18 @@ public class VehicleListener extends AbstractPluginReceiver implements Listener 
 
         // if there are climb blocks, make sure the material matches the whitelist
         return blocksConfig.getClimbBlocks().contains(twoBlocksAhead.getBlock().getType());
+    }
+
+    private double getBlockHeight(Block block) {
+        switch (block.getType().toString()) {
+            case "DIRT_PATH":
+            case "FARMLAND":
+            case "HONEY_BLOCK":
+            case "SOUL_SAND":
+                return 0.1;
+            default:
+                return 1.0;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #48

- Adjust the calculation for the blocks below by subtracting 0.1 instead of 1.0 in the onVehicleUpdate method.
- Add a new method getBlockHeight to calculate the correct height for different block types.
- Modify the twoBlocksAhead.setY calculation to use the getBlockHeight method.
- Instead of using block.getType() for comparison, use block.getType().toString() to ensure compatibility with older Minecraft versions where block types like `HONEY_BLOCK` weren't available.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/A5H73Y/Carz/pull/51?shareId=96359812-b47a-4dbd-9981-313a95c112f5).